### PR TITLE
fix: Adds timed menu update

### DIFF
--- a/fc_button.js
+++ b/fc_button.js
@@ -417,6 +417,15 @@ function FCMenu() {
         if (Game.onMenu !== 'fc_menu') {
             return Game.oldUpdateMenu();
         }
+
+        if (!Game.callingMenu) {
+          Game.callingMenu = true
+          setTimeout(() => {
+            Game.callingMenu = false
+            Game.UpdateMenu()
+          }, 1000)
+        }
+
         var currentCookies, maxCookies, isTarget, isMax, targetTxt, maxTxt,
             currPrestige, resetPrestige, prestigeDifference,
             currHC, resetHC, cps, baseChosen, frenzyChosen, clickStr, buildTable,


### PR DESCRIPTION
Temporary workaround by adding setTimeout on menu
and adding a global state variable to prevent multiple
loading calls

Fixes: #21 from remote
https://github.com/Mtarnuhal/FrozenCookies/issues/21